### PR TITLE
remove link and nominate links, update c2a

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,8 +19,6 @@
       <nav>
         <a href="/history">History</a><br>
         <a href="/rules">Rules &amp; Eligibility</a><br>
-        <a href="https://docs.google.com/forms/d/e/1FAIpQLScPvki4Xf8-dGBGjbn_nfaDCTHWwtBymEOojyEo9JhWD9eMhQ/viewform" target="_blank">Nominate Data</a><br>
-        <a href="http://vote.opendatavote.org/" target="_blank">Vote</a>
       </nav>
     </div>
     <div class="column-2">

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -9,8 +9,6 @@
       <nav>
         <a href="/history">History</a>
         <a href="/rules">Rules &amp; Eligibility</a>
-        <a href="https://docs.google.com/forms/d/e/1FAIpQLScPvki4Xf8-dGBGjbn_nfaDCTHWwtBymEOojyEo9JhWD9eMhQ/viewform" target="_blank">Nominate Data</a>
-        <a href="http://vote.opendatavote.org/" target="_blank">Vote</a>
       </nav>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -12,11 +12,11 @@ header:
     link: "#call-to-action"
 
 c2a:
-  title: "You vote for data sets that nonprofits requested. The City releases the data with the most votes!"
-  phase: "Vote Now!"
+  title: "OpenDataVote in Philadelphia has come to a close!"
+  phase: "Winning organizations announced."
   button:
-    text: "Vote Now"
-    link: "http://vote.opendatavote.org/"
+    text: "Read more"
+    link: "/history"
 
 purpose:
   title: "OpenDataVote encourages citizens to get involved in the process of open government and cultivates government transparency through the release of data."
@@ -144,11 +144,10 @@ partners:
 <section id="call-to-action" class="call-to-action">
   <div class="container">
     <div class="row stack-sm align-center columns-center">
-      <div class="column-4">
+      <div class="column-6 text-center">
         <span class="phase">{{ page.c2a.phase }}</span>
         <h2 class="h4">{{ page.c2a.title }}</h2>
-      </div>
-      <div class="column-2">
+        <br>
         <a href="{{ page.c2a.button.link }}" class="btn btn-secondary btn-large" target="_blank">{{ page.c2a.button.text }}</a>
       </div>
     </div>


### PR DESCRIPTION
fixes #53
Removes vote and nominate links in nav and footer. Updates call to action.

<img width="1128" alt="screen shot 2017-05-19 at 3 55 46 pm" src="https://cloud.githubusercontent.com/assets/1928955/26264719/d13ebb5e-3cab-11e7-84d9-7eabefec44dc.png">

