### PR TITLE
Fix Vagrant ansible_local provisioner failing on trusty64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ if ["up", "provision", "status"].include?(ARGV.first)
 end
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.network "private_network", ip: "192.168.50.4"
 

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -2,7 +2,7 @@
   version: 2.2.0
 
 - src: azavea.pip
-  version: 1.0.0
+  version: 1.0.1
 
 - src: azavea.ntp
   version: 0.2.0


### PR DESCRIPTION
## Overview

* Bump Vagrant box
* Bump ansible pip role version

Connects https://github.com/azavea/operations/issues/214
Closes #70 

## Testing Instructions

Provision the VM from scratch:

```bash
$ vagrant destroy -f && ./scripts/setup
```

Bring a development server up from within the VM:

```bash
$ vagrant ssh
vagrant@vagrant:/vagrant$ ./scripts/server
...
```

Test in your browser with link in the `server` output.